### PR TITLE
feat: nightly workflow to fetch and deploy GW2 achievement data cache to GitHub Pages

### DIFF
--- a/.github/workflows/cache-to-pages.yml
+++ b/.github/workflows/cache-to-pages.yml
@@ -1,0 +1,36 @@
+name: Nightly GW2 Data Cache to Pages
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+env:
+  WORKING_DIRECTORY: client
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+
+      - name: Fetch GW2 achievement data
+        run: npm run fetch:gw2-achievement-data
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./client/public/data
+          destination_dir: data 


### PR DESCRIPTION
## Summary

This PR adds a GitHub Actions workflow that runs nightly to fetch the latest GW2 achievement data and deploys the resulting cache files (`achievement-categories.json`, `achievement-groups.json`, `achievements.json`) to the project's GitHub Pages under the `data/` directory.

### Details
- Runs the `fetch-gw2-achievement-data.ts` script nightly at 3:00 UTC and on manual dispatch.
- Installs dependencies and executes the data-fetch script in the `client` directory.
- Publishes the generated `client/public/data/` directory to the `gh-pages` branch under `data/` using `peaceiris/actions-gh-pages`.
- Uses an environment variable for the working directory for maintainability and consistency with other workflows.

### Motivation
- Keeps the public data cache up-to-date for the client and any external consumers.
- Automates the process, reducing manual intervention and risk of stale data.

### Notes
- No compression is performed; files are uploaded as plain JSON for maximum compatibility.
- No changes to client code or fetch URLs are required unless you want to fetch directly from GitHub Pages in production.

---
Closes # (if applicable)
